### PR TITLE
Little refactoring and perfomance

### DIFF
--- a/src/CallSharp/ExtensionMethods.cs
+++ b/src/CallSharp/ExtensionMethods.cs
@@ -103,19 +103,14 @@ namespace CallSharp
     {
       var result = new List<object>();
 
-      foreach (var type in TypeDatabase.ParseableTypes)
+      foreach (var m in TypeDatabase.ParseableTypesDict.Values)
       {
-        foreach (var m in type.GetMethods().Where(
-          x => x.Name.Equals("TryParse") 
-          && x.GetParameters().Length == 2))
+        // see http://stackoverflow.com/questions/569249/methodinfo-invoke-with-out-parameter
+        object[] pars = { text, null };
+        bool ok = (bool) m.Invoke(null, pars);
+        if (ok)
         {
-          // see http://stackoverflow.com/questions/569249/methodinfo-invoke-with-out-parameter
-          object[] pars = {text, null};
-          bool ok = (bool) m.Invoke(null, pars);
-          if (ok)
-          {
             result.Add(pars[1]);
-          }
         }
       }
       return result;

--- a/src/CallSharp/MemberDatabase.cs
+++ b/src/CallSharp/MemberDatabase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -80,7 +81,8 @@ namespace CallSharp
         && (
           m.DeclaringType.IsIn(TypeDatabase.CoreTypes)
           ||
-          m.DeclaringType.Name.Contains("IEnumerable") // hack ;(
+          m.DeclaringType.GetInterfaces().Any(i => i.IsGenericType && // no more hack ;)
+                                                   i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
         )
         && m.ReturnType != ignoreThisOutputType
         && m.IsStatic))
@@ -222,7 +224,7 @@ namespace CallSharp
       foreach (var m in FindOneToOneNonStatic(input.GetType(), output.GetType()))
       {
         var cookie = m.InvokeWithNoArgument(input);
-        if (cookie != null && output.Equals(cookie?.ReturnValue))
+        if (cookie != null && output.Equals(cookie.ReturnValue))
         {
           yield return cookie.ToString(callChain);
           foundSomething = true;

--- a/src/CallSharp/MethodCallCookie.cs
+++ b/src/CallSharp/MethodCallCookie.cs
@@ -62,15 +62,14 @@ namespace CallSharp
         sb.Append(MethodCalled.Name).Append("(");
 
         int start = MethodCalled.IsStatic ? 1 : 0;
-        for (int i = start; i < Arguments.Length; i++)
+        for (var i = start; i < Arguments.Length; i++)
         {
           var arg = Arguments[i];
           bool isParams = methodParams[i].IsParams();
           
           // caveat: calling a params[] really passes in a single
           // 0-sized array :( need special handling
-          var arr = arg as Array;
-          if (arr != null && arr.Length == 0)
+          if (arg is Array arr && arr.Length == 0)
             break;
 
           // todo: literalize argument into code
@@ -84,16 +83,20 @@ namespace CallSharp
           }
           else if (arg is char[])
           {
-            if (!isParams) sb.Append("new char[]{");
+            if (!isParams) 
+              sb.Append("new char[]{");
+            
             sb.Append(string.Join(",", ((char[]) arg).Select(c => "'" + c + "'")));
-            if (!isParams) sb.Append("}");
+            
+            if (!isParams) 
+              sb.Append("}");
           }
           else
           {
             sb.Append(arg);
           }
 
-          if (i+1 != Arguments.Length)
+          if (i + 1 != Arguments.Length)
             sb.Append(", ");
         }
 

--- a/src/CallSharp/ObservableHashSet.cs
+++ b/src/CallSharp/ObservableHashSet.cs
@@ -81,11 +81,7 @@ namespace CallSharp
     /// <summary>
     /// Gets the IEqualityComparer&lt;T&gt; object that is used to determine equality for the values in the set.
     /// </summary>
-    public IEqualityComparer<T> Comparer
-    {
-      get { return hashSet.Comparer; }
-    }
-
+    public IEqualityComparer<T> Comparer => hashSet.Comparer;
 
     /// <summary>
     /// Gets the number of elements contained in the <see cref="ObservableHashSet&lt;T&gt;"/>.
@@ -93,22 +89,16 @@ namespace CallSharp
     /// <returns>
     /// The number of elements contained in the <see cref="ObservableHashSet&lt;T&gt;"/>.
     ///   </returns>
-    public int Count
-    {
-      get { return hashSet.Count; }
-    }
+    public int Count => hashSet.Count;
 
     /// <summary>
     /// Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1"/> is read-only.
     /// </summary>
     /// <returns>true if the <see cref="T:System.Collections.Generic.ICollection`1"/> is read-only; otherwise, false.
     ///   </returns>
-    bool ICollection<T>.IsReadOnly
-    {
-      get { return ((ICollection<T>)hashSet).IsReadOnly; }
-    }
+    bool ICollection<T>.IsReadOnly => ((ICollection<T>)hashSet).IsReadOnly;
 
-    #endregion
+  #endregion
 
     #region Events
 
@@ -135,10 +125,7 @@ namespace CallSharp
 
     private void RaisePropertyChanged(string propertyName)
     {
-      if (PropertyChanged != null)
-      {
-        PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
-      }
+      PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
     #endregion

--- a/src/CallSharp/PermuteUtils.cs
+++ b/src/CallSharp/PermuteUtils.cs
@@ -2,7 +2,7 @@
 
 namespace CallSharp
 {
-  public class PermuteUtils
+  public static class PermuteUtils
   {
     // Returns an enumeration of enumerators, one for each permutation
     // of the input.

--- a/src/CallSharp/ScaleToWindowSizeBehavior.cs
+++ b/src/CallSharp/ScaleToWindowSizeBehavior.cs
@@ -72,15 +72,14 @@ namespace CallSharp
 
     private static object OnCoerceScaleValue(DependencyObject d, object baseValue)
     {
-      if (baseValue is double)
+      if (baseValue is double doubleValue)
       {
-        double value = (double) baseValue;
-        if (double.IsNaN(value))
+        if (double.IsNaN(doubleValue))
         {
           return 1.0f;
         }
-        value = Math.Max(0.1, value);
-        return value;
+        doubleValue = Math.Max(0.1, doubleValue);
+        return doubleValue;
       }
       return 1.0f;
     }


### PR DESCRIPTION
ParseableTypes -> ParseableTypesDict and InferTypes() method perfomance due to dictionary usage.
FindAnyToOneStatic() hack and redudant null propagation removed.
MethodCallCookie.cs, ObservableHashSet.cs and ScaleToWindowSizeBehavior.cs refactoring.